### PR TITLE
feat: add group annotation for Customer

### DIFF
--- a/src/Controller/CustomerController.php
+++ b/src/Controller/CustomerController.php
@@ -6,6 +6,7 @@ use App\Entity\Customer;
 use App\Repository\CustomerRepository;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -26,9 +27,10 @@ class CustomerController extends AbstractController
     #[Route('/api/customers', name: 'customers', methods: ['GET'])]
     public function getCustomerList(CustomerRepository $customerRepository, SerializerInterface $serializer,  Request $request): JsonResponse
     {
-
         $customerList = $customerRepository->findAll();
-        $jsonCustomerList = $serializer->serialize($customerList, 'json');
+
+        $context = SerializationContext::create()->setGroups(['groups' => 'getCustomers']);
+        $jsonCustomerList = $serializer->serialize($customerList, 'json', $context);
 
         return new JsonResponse($jsonCustomerList, Response::HTTP_OK, [], true);
     }
@@ -36,7 +38,8 @@ class CustomerController extends AbstractController
     #[Route('/api/customers/{id}', name: 'detailCustomer', methods: ['GET'])]
     public function getDetailCustomer(Customer $customer, SerializerInterface $serializer): JsonResponse 
     {
-        $jsonCustomer = $serializer->serialize($customer, 'json');
+        $context = SerializationContext::create()->setGroups(['groups' => 'getCustomers']);
+        $jsonCustomer = $serializer->serialize($customer, 'json', $context);
 
         return new JsonResponse($jsonCustomer, Response::HTTP_OK, ['accept' => 'json'], true);
     }
@@ -62,7 +65,8 @@ class CustomerController extends AbstractController
         $em->persist($customer);
         $em->flush();
 
-        $jsonCustomer = $serializer->serialize($customer, 'json');
+        $context = SerializationContext::create()->setGroups(['groups' => 'getCustomers']);
+        $jsonCustomer = $serializer->serialize($customer, 'json', $context);
         $location = $urlGenerator->generate('detailCustomer', ['id' => $customer->getId()], UrlGeneratorInterface::ABSOLUTE_URL);
 
         return new JsonResponse($jsonCustomer, Response::HTTP_CREATED, ["Location" => $location], true);

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use App\Repository\CustomerRepository;
 use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: CustomerRepository::class)]
 class Customer
@@ -11,19 +12,24 @@ class Customer
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(["getCustomers"])]
     private ?int $id = null;
 
     #[ORM\Column(length: 255)]
+    #[Groups(["getCustomers"])]
     private ?string $lastName = null;
 
     #[ORM\Column(length: 255)]
+    #[Groups(["getCustomers"])]
     private ?string $firstName = null;
 
     #[ORM\Column(length: 255)]
+    #[Groups(["getCustomers"])]
     private ?string $email = null;
 
     #[ORM\ManyToOne(inversedBy: 'customers')]
     #[ORM\JoinColumn(nullable: false)]
+    #[Groups(["getCustomers"])]
     private ?User $user = null;
 
     public function getId(): ?int

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -8,6 +8,8 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use JMS\Serializer\Annotation\Groups;
+
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
@@ -15,9 +17,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(["getCustomers"])]
     private ?int $id = null;
 
     #[ORM\Column(length: 180, unique: true)]
+    #[Groups(["getCustomers"])]
     private ?string $username = null;
 
     /**


### PR DESCRIPTION
### Ancien comportements
- Lors des méthodes `GET` et `POST`, la réponse JSON renvoie toutes les données de l'utilisateur lié au consommateur, dont le mot de passe hasher et la liste entière des consommateurs.

### Nouveaux comportements
- Ajout du groupe d'annotation `getCustomers `, afin de filtrer les informations de l'utilisateur

### Issue
- https://github.com/AurelieBnc/Api-BileMo/issues/11

### Dépendances (pull requests) :
- https://github.com/AurelieBnc/Api-BileMo/pull/31
- https://github.com/AurelieBnc/Api-BileMo/pull/32

## _____________ ENGLISH ___________________
### Old behaviors
- During the `GET `and `POST `methods, the JSON response returns all user data linked to the consumer, including the hasher password and the entire list of consumers.

### New behaviors
- Added the `getCustomers `annotation group, to filter user information

### Issue
- https://github.com/AurelieBnc/Api-BileMo/issues/11

### Dependencies (pull requests):
- https://github.com/AurelieBnc/Api-BileMo/pull/31
- https://github.com/AurelieBnc/Api-BileMo/pull/32