### PR TITLE
Feat errors management

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "doctrine/annotations": "^2.0",
         "doctrine/doctrine-bundle": "^2.11",
         "doctrine/doctrine-migrations-bundle": "^3.3",
         "doctrine/orm": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8e88de8b6d201386e683974aeafc4d0",
+    "content-hash": "c7aa04944fc1f3bd93eec2d540900220",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1545,16 +1545,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.25.0",
+            "version": "1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240"
+                "reference": "231e3186624c03d7e7c890ec662b81e6b0405227"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bd84b629c8de41aa2ae82c067c955e06f1b00240",
-                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/231e3186624c03d7e7c890ec662b81e6b0405227",
+                "reference": "231e3186624c03d7e7c890ec662b81e6b0405227",
                 "shasum": ""
             },
             "require": {
@@ -1586,9 +1586,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.25.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.26.0"
             },
-            "time": "2024-01-04T17:06:16+00:00"
+            "time": "2024-02-23T16:05:55+00:00"
         },
         {
             "name": "psr/cache",

--- a/src/Controller/CustomerController.php
+++ b/src/Controller/CustomerController.php
@@ -17,7 +17,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class CustomerController extends AbstractController
 {
-
     /**
      * @param CustomerRepository $customerRepository
      * @param SerializerInterface $serializer

--- a/src/Controller/PhoneController.php
+++ b/src/Controller/PhoneController.php
@@ -22,7 +22,6 @@ class PhoneController extends AbstractController
     #[Route('/api/phones', name: 'phones', methods: ['GET'])]
     public function getPhoneList(PhoneRepository $phoneRepository, SerializerInterface $serializer,  Request $request): JsonResponse
     {
-
         $phoneList = $phoneRepository->findAll();
         $jsonPhoneList = $serializer->serialize($phoneList, 'json');
 

--- a/src/EventSubscriber/ExceptionSubscriber.php
+++ b/src/EventSubscriber/ExceptionSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ExceptionSubscriber implements EventSubscriberInterface
+{
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        $exception = $event->getThrowable();
+
+        if ($exception instanceof HttpException) {
+            $data = [
+                'status' => $exception->getStatusCode(),
+                'message' => $exception->getMessage()
+            ];
+
+            $event->setResponse(new JsonResponse($data));
+      } else {
+            $data = [
+                'status' => 500,
+                'message' => $exception->getMessage()
+            ];
+
+            $event->setResponse(new JsonResponse($data));
+      }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => 'onKernelException',
+        ];
+    }
+}


### PR DESCRIPTION
### Nouveaux comportements
- Création d'un écouteur d'exception afin de convertir les erreurs HTTP de symfony en JsonResponse

### Issue
- https://github.com/AurelieBnc/Api-BileMo/issues/12

### Dépendances (pull requests) :
none

## _____________ ENGLISH ___________________
### New behaviors
- Creation of an exception listener to convert HTTP errors from symfony into JsonResponse

### Issue
- https://github.com/AurelieBnc/Api-BileMo/issues/12

### Dependencies (pull requests):
none