### PR TITLE
Feat cache

### DIFF
--- a/src/Controller/PhoneController.php
+++ b/src/Controller/PhoneController.php
@@ -10,6 +10,8 @@ use Symfony\Component\Routing\Attribute\Route;
 use JMS\Serializer\SerializerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 class PhoneController extends AbstractController
 {

--- a/src/EventListener/CacheCustomerListener.php
+++ b/src/EventListener/CacheCustomerListener.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\Customer;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\Event\PostLoadEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Events;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\SerializerInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+#[AsEntityListener(event: Events::prePersist, method: 'prePersist', entity: Customer::class)]
+#[AsEntityListener(event: Events::postRemove, method: 'postRemove', entity: Customer::class)]
+#[AsEntityListener(event: Events::postLoad, method: 'postLoad', entity: Customer::class)]
+class CacheCustomerListener
+{
+    private $cachePool;
+    private $serializer;
+
+    public function __construct(TagAwareCacheInterface $cachePool, SerializerInterface $serializer) {
+         $this->cachePool = $cachePool;
+         $this->serializer = $serializer;
+    }
+
+    public function prePersist(Customer $customer, PrePersistEventArgs $args): void
+    {
+        $entity = $args->getObject();
+        if (!$entity instanceof Customer) {
+            return;
+        }
+
+        $this->cachePool->invalidateTags(['customersCache']);
+    }
+
+    public function postRemove(Customer $customer, PostRemoveEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof Customer) {
+            return;
+        }
+
+        $this->cachePool->invalidateTags(['customersCache']);
+    }
+
+    public function postLoad(Customer $customer, PostLoadEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof Customer) {
+            return;
+        }
+
+        $idCache = "getCustomer-".$customer->getId();
+        $serializer = $this->serializer;
+
+        $this->cachePool->get($idCache, function (ItemInterface $item) use ($customer, $serializer){
+            $item->tag('customersCache');
+            $item->expiresAfter(600);
+            $context = SerializationContext::create()->setGroups(['groups' => 'getCustomers']);
+
+            return $serializer->serialize($customer, 'json', $context);
+        });
+
+    }
+}

--- a/src/EventListener/CachePhoneListener.php
+++ b/src/EventListener/CachePhoneListener.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\Phone;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\Event\PostLoadEventArgs;
+use Doctrine\ORM\Events;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\SerializerInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+#[AsEntityListener(event: Events::postLoad, method: 'postLoad', entity: Phone::class)]
+class CachePhoneListener
+{
+    private $cachePool;
+    private $serializer;
+
+    public function __construct(TagAwareCacheInterface $cachePool, SerializerInterface $serializer) {
+         $this->cachePool = $cachePool;
+         $this->serializer = $serializer;
+    }
+
+    public function postLoad(Phone $phone, PostLoadEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof Phone) {
+            return;
+        }
+
+        $idCache = "getPhone-".$phone->getId();
+        $serializer = $this->serializer;
+
+        $this->cachePool->get($idCache, function (ItemInterface $item) use ($phone, $serializer){
+            $item->tag('PhonesCache');
+            $item->expiresAfter(600);
+            $context = SerializationContext::create()->setGroups(['groups' => 'getPhones']);
+echo('pas de cache');
+            return $serializer->serialize($phone, 'json', $context);
+        });
+
+    }
+}


### PR DESCRIPTION
### Nouveaux comportements
- Ajout d'un entity listener pour `Phone` : gérant le cache des `postLoad` de l'entité.
- Ajout d'un entity listener pour `Customer`: gérant le cache de `prePersist`, `postRemove`, `postLoad`.

Chaque requête est identifiée comme un item unique et taguée en groupe, afin de conserver les données en cache pendant 10 minutes.
Les groupes servent à nettoyer le cache lors de la suppression ou de la création d'une nouvelle instance de Customer.

### Issue
- https://github.com/AurelieBnc/Api-BileMo/issues/17

## _____________ ENGLISH ___________________
### New behaviors
- Added an entity listener for `Phone`: managing the entity's `postLoad` cache.
- Added an entity listener for `Customer`: managing the cache of `prePersist`, `postRemove`, `postLoad`.

Each query is identified as a unique item and tagged as a group, in order to keep the data cached for 10 minutes.
Groups are used to clean the cache when deleting or creating a new Customer instance.

### Issue
- https://github.com/AurelieBnc/Api-BileMo/issues/17